### PR TITLE
Update VMF template

### DIFF
--- a/.template-vmf/%%name.mod
+++ b/.template-vmf/%%name.mod
@@ -1,15 +1,12 @@
 return {
 	run = function()
-		fassert(rawget(_G, "new_mod"), "%%title must be lower than Vermintide Mod Framework in your launcher's load order.")
+		fassert(rawget(_G, "new_mod"), "`%%title` mod must be lower than Vermintide Mod Framework in your launcher's load order.")
 
 		new_mod("%%name", {
 			mod_script       = "scripts/mods/%%name/%%name",
 			mod_data         = "scripts/mods/%%name/%%name_data",
 			mod_localization = "scripts/mods/%%name/%%name_localization",
 		})
-
-		-- We return an empty table to silence warnings about not returning a callback table.
-		return { }
 	end,
 	packages = {
 		"resource_packages/%%name/%%name",

--- a/.template-vmf/scripts/mods/%%name/%%name_data.lua
+++ b/.template-vmf/scripts/mods/%%name/%%name_data.lua
@@ -1,6 +1,7 @@
 local mod = get_mod("%%name")
 
 return {
-	name = mod:localize("mod_name"),
+	name = "%%title",
 	description = mod:localize("mod_description"),
+	is_togglable = true,
 }

--- a/.template-vmf/scripts/mods/%%name/%%name_localization.lua
+++ b/.template-vmf/scripts/mods/%%name/%%name_localization.lua
@@ -1,7 +1,4 @@
 return {
-	mod_name = {
-		en = "%%name",
-	},
 	mod_description = {
 		en = "%%description",
 	},


### PR DESCRIPTION
+ Quoted mod name inside assert message with backticks and postfixed it with "mod", so the message is more clear to the user.
+ Removed `return {}` at the end of the `run` callback, because the warning for not having it is controlled by modder and is disabled by default. We should also ask Robin to just remove it, or move to `info`, but this is out of the scope of this PR.
+ Returned `is_togglable = true` back because it's a convention to have all mods togglable unless there's the reason not to.
+ Removed mod name localization.