### PR TITLE
Update "create" command to use new, required files.

### DIFF
--- a/scripts/tools/templater.js
+++ b/scripts/tools/templater.js
@@ -95,8 +95,8 @@ async function copyTemplate(params) {
                 // Copy files that shouldn't be modified
                 if (config.get('coreSrc').length > 0) {
 
-                    //these function should probably be spun off into a more robust solution
-                    //something searches the VT2 sdk install folder for a list of required folders/files
+                    //these functions should probably be spun off into a more robust solution
+                    //something that searches the VT2 sdk install folder for a list of required folders/files
                     copyFolderRecursiveSync(sdkDir+"/streamable_resources/core", modDir)
                     copyFileSync(sdkDir+"/streamable_resources/lua_preprocessor_defines.config", modDir)
                     

--- a/scripts/tools/templater.js
+++ b/scripts/tools/templater.js
@@ -9,6 +9,8 @@ const config = require('../modules/config');
 
 const modTools = require('./mod_tools');
 
+const fs = require('fs');
+
 // Throws if template folder doesn't exist or doesn't have itemPreview file in it
 async function validateTemplate(templateDir) {
 
@@ -21,11 +23,50 @@ async function validateTemplate(templateDir) {
     }
 }
 
+//pair of functions to copy a file or folder if the source exists
+function copyFileSync( source, target ) {
+    if (fs.existsSync( source )) {
+        var targetFile = target;
+
+        if ( fs.existsSync( target ) ) {
+            if ( fs.lstatSync( target ).isDirectory() ) {
+                targetFile = path.join( target, path.basename( source ) );
+            }
+        }
+
+        fs.writeFileSync(targetFile, fs.readFileSync(source));
+    }
+}
+
+function copyFolderRecursiveSync( source, target) {
+    if (fs.existsSync( source )) {
+        var files = [];
+
+        var targetFolder = path.join( target, path.basename( source ) );
+        if ( !fs.existsSync( targetFolder ) ) {
+            fs.mkdirSync( targetFolder );
+        }
+
+        if ( fs.lstatSync( source ).isDirectory() ) {
+            files = fs.readdirSync( source );
+            files.forEach( function ( file ) {
+                var curSource = path.join( source, file );
+                if ( fs.lstatSync( curSource ).isDirectory() ) {
+                    copyFolderRecursiveSync( curSource, targetFolder );
+                } else {
+                    copyFileSync( curSource, targetFolder );
+                }
+            } );
+        }
+    }
+}
+
 // Copies and renames mod template folder and its contents
 async function copyTemplate(params) {
 
     let modName = params.name;
     let modDir = modTools.getModDir(modName);
+    let sdkDir = await modTools.getModToolsDir();
 
     // Check that template is valid
     await validateTemplate(config.get('templateDir'));
@@ -53,6 +94,12 @@ async function copyTemplate(params) {
 
                 // Copy files that shouldn't be modified
                 if (config.get('coreSrc').length > 0) {
+
+                    //these function should probably be spun off into a more robust solution
+                    //something searches the VT2 sdk install folder for a list of required folders/files
+                    copyFolderRecursiveSync(sdkDir+"/streamable_resources/core", modDir)
+                    copyFileSync(sdkDir+"/streamable_resources/lua_preprocessor_defines.config", modDir)
+                    
                     vinyl.src(config.get('coreSrc'), { base: config.get('templateDir') })
                         .pipe(vinyl.dest(modDir))
                         .on('error', reject)


### PR DESCRIPTION
The requirements for building a mod have changed in the past years to require `physx_411` and `lua_preprocessor_defines.config` files upon mod building. The PR addresses this for new mods by altering the "create" command to copy the required files over from the VT2 SDK tools install, as specified in the `.vmbrc`.