### PR TITLE
Stream file fix

### DIFF
--- a/scripts/modules/config.js
+++ b/scripts/modules/config.js
@@ -104,9 +104,10 @@ let values = {
     coreSrc: undefined,  // Blob of files to copy without changes
     modSrc: undefined,   // Blob of files to copy and replace
 
-    defaultBundleDir: undefined,  // Default folder in which the built bundle is gonna be stored
-    bundleExtension: undefined,   // Extension of built bundle file
-    modFileExtension: '.mod',     // Extension of .mod file
+    defaultBundleDir: undefined,    // Default folder in which the built bundle is gonna be stored
+    bundleExtension: undefined,     // Extension of built bundle file
+    modFileExtension: '.mod',       // Extension of .mod file
+    streamFileExtension: '.stream', // Extension of .stream file
 
     useNewFormat: undefined,      // Determines whether bundle is renamed and whether .mod file is copied
     ignoreBuildErrors: undefined, // Determines whether stingray.exe exit code should be ignored

--- a/scripts/tools/builder.js
+++ b/scripts/tools/builder.js
@@ -1,6 +1,5 @@
 const child_process = require('child_process');
 const vinyl = require('vinyl-fs');
-const rename = require('gulp-rename');
 const del = require('del');
 const merge = require('merge-stream');
 
@@ -262,21 +261,10 @@ async function _copyModFiles(modName, buildDir, bundleDir, modWorkshopDir) {
             ], { base: modTools.getModDir(modName)});
         }
 
-        let bundleStream = vinyl.src([
-            buildDir + '/*([0-f])',
-            '!' + buildDir + '/dlc'
-        ], { base: buildDir })
-            .pipe(rename(p => {
+        let bundleStream = modTools.bundleStreamer('bundleExtension', buildDir, useNewFormat, modName, reject);
+        let streamFileStream = modTools.bundleStreamer('streamFileExtension', buildDir, useNewFormat, modName, reject);
 
-                if (!useNewFormat) {
-                    p.basename = modTools.hashModName(modName);
-                }
-
-                p.extname = config.get('bundleExtension');
-            }))
-            .on('error', reject);
-
-        let mergedStream = useNewFormat ? merge(modFileStream, bundleStream) : bundleStream;
+        let mergedStream = useNewFormat ? merge(modFileStream, bundleStream, streamFileStream) : bundleStream;
 
         mergedStream = mergedStream.pipe(vinyl.dest(bundleDir)).on('error', reject);
 

--- a/scripts/tools/builder.js
+++ b/scripts/tools/builder.js
@@ -262,9 +262,8 @@ async function _copyModFiles(modName, buildDir, bundleDir, modWorkshopDir) {
         }
 
         let bundleStream = modTools.bundleStreamer('bundleExtension', buildDir, useNewFormat, modName, reject);
-        let streamFileStream = modTools.bundleStreamer('streamFileExtension', buildDir, useNewFormat, modName, reject);
 
-        let mergedStream = useNewFormat ? merge(modFileStream, bundleStream, streamFileStream) : bundleStream;
+        let mergedStream = useNewFormat ? merge(modFileStream, bundleStream) : bundleStream;
 
         mergedStream = mergedStream.pipe(vinyl.dest(bundleDir)).on('error', reject);
 

--- a/scripts/tools/mod_tools.js
+++ b/scripts/tools/mod_tools.js
@@ -1,5 +1,7 @@
 const vdf = require('vdf');
 const crypto = require('crypto');
+const vinyl = require('vinyl-fs');
+const rename = require('gulp-rename');
 
 const print = require('../print');
 
@@ -348,6 +350,38 @@ function hashModName(modName) {
     return hash.substring(0, 16);
 }
 
+// Returns a gulp pattern array, used for matching file types when copying files over from '.temp' folder
+function buildBundleGulp(buildDir, extConfigName){
+    let gulp_array = [
+        buildDir + '/*([0-f])',
+        '!' + buildDir + '/dlc'
+    ]
+    
+    if (extConfigName != 'bundleExtension'){
+        gulp_array[0] += config.get(extConfigName);
+    }s
+
+    return gulp_array
+}
+
+// Returns the bundle's file stream and initiates the process of copying the bundle file to the buildDir
+function bundleStreamer(extConfigName, buildDir, useNewFormat, modName, reject) {
+    let bundleStream = vinyl.src(
+        buildBundleGulp(buildDir, extConfigName),
+        { base: buildDir })
+        .pipe(rename(p => {
+
+            if (!useNewFormat) {
+                p.basename = hashModName(modName);
+            }
+
+            p.extname = config.get(extConfigName);
+        }))
+        .on('error', reject);
+
+    return bundleStream
+}
+
 
 exports.validateModNames = validateModNames;
 exports.validModName = validModName;
@@ -367,3 +401,5 @@ exports.getWorkshopParams = getWorkshopParams;
 exports.getFirstModName = getFirstModName;
 exports.getModNames = getModNames;
 exports.getBuildParams = getBuildParams;
+
+exports.bundleStreamer = bundleStreamer;

--- a/scripts/tools/mod_tools.js
+++ b/scripts/tools/mod_tools.js
@@ -359,7 +359,7 @@ function buildBundleGulp(buildDir, extConfigName){
     
     if (extConfigName != 'bundleExtension'){
         gulp_array[0] += config.get(extConfigName);
-    }s
+    }
 
     return gulp_array
 }

--- a/scripts/tools/mod_tools.js
+++ b/scripts/tools/mod_tools.js
@@ -350,24 +350,16 @@ function hashModName(modName) {
     return hash.substring(0, 16);
 }
 
-// Returns a gulp pattern array, used for matching file types when copying files over from '.temp' folder
-function buildBundleGulp(buildDir, extConfigName){
+// Returns the bundle's file stream and initiates the process of copying the bundle file to the buildDir
+function bundleStreamer(extConfigName, buildDir, useNewFormat, modName, reject) {
     let gulp_array = [
         buildDir + '/*([0-f])',
+        buildDir + '/*([0-f]).stream',
         '!' + buildDir + '/dlc'
     ]
     
-    if (extConfigName != 'bundleExtension'){
-        gulp_array[0] += config.get(extConfigName);
-    }
-
-    return gulp_array
-}
-
-// Returns the bundle's file stream and initiates the process of copying the bundle file to the buildDir
-function bundleStreamer(extConfigName, buildDir, useNewFormat, modName, reject) {
     let bundleStream = vinyl.src(
-        buildBundleGulp(buildDir, extConfigName),
+        gulp_array,
         { base: buildDir })
         .pipe(rename(p => {
 
@@ -375,7 +367,9 @@ function bundleStreamer(extConfigName, buildDir, useNewFormat, modName, reject) 
                 p.basename = hashModName(modName);
             }
 
-            p.extname = config.get(extConfigName);
+            if (!p.extname){
+                p.extname = config.get(extConfigName);
+            }
         }))
         .on('error', reject);
 


### PR DESCRIPTION
Stream files that are generated with the SDK are not copied over from the `.temp` folder into the local workshop folder. This can cause crashes in the mod when it tries to load in textures resources inside the stream file. 