### PR TITLE
Fix invalid bundle csv red herrings

### DIFF
--- a/scripts/tools/builder.js
+++ b/scripts/tools/builder.js
@@ -211,7 +211,7 @@ function _outputFailedBundles(data, modName) {
     bundles.splice(0, 1);
 
     for (let line of bundles) {
-        let bundle = line.split(', ');
+        let bundle = line.split(',');
 
         // Each line has to be bundle, "resource", "type", "bytes"
         if (bundle.length < 4) {


### PR DESCRIPTION
I did a quick test in jsfiddle to verify that this will fix the issue and not cause regressions.

```
let line = 'resource_packages/Lifes Hard Everywhere/Lifes Hard Everywhere.package,Lifes Hard Everywhere,mod, 0'

let bundle = line.split(',')
if (bundle.length < 4) {
	console.error(`Incorrect processed_bundles.csv string\n${bundle}`)
}
else {
	console.log(`Valid csv`)
}

console.log(bundle[3] == 0)
```
Output:
`Valid csv`
`true`

What this means is
1. It no longer thinks it is an invalid line regardless of spaces after commas, and
2. Later on in the function, we check if `bundle[3] == 0` which will still be true if it is 0 prefixed with a space.
